### PR TITLE
feat: add testcases for hold violations

### DIFF
--- a/hold_violations_1/config.yaml
+++ b/hold_violations_1/config.yaml
@@ -1,0 +1,8 @@
+DESIGN_NAME: hold_violations_1
+VERILOG_FILES: dir::src/*.sv
+CLOCK_PORT: clk_i
+CLOCK_PERIOD: 10 # 10ns = 100MHz
+
+FP_CORE_UTIL: 30
+
+RSZ_DONT_TOUCH_RX: register.*

--- a/hold_violations_1/harden.py
+++ b/hold_violations_1/harden.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright 2025 LibreLane Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import yaml
+import click
+
+from librelane.flows import Flow, FlowError
+from librelane.config import Macro
+from librelane.steps import Checker, OpenROAD, DeferredStepError
+
+__dir__ = os.path.dirname(os.path.realpath(__file__))
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option("--pdk-root", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--pdk", type=str)
+@click.option("--run-tag", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--gui", is_flag=True)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def main(
+    pdk_root,
+    pdk,
+    run_tag,
+    gui,
+    args,
+):
+    target_flow = Flow.factory.get("Classic")
+
+    # Don't throw exception on hold violations
+    target_flow.Steps.remove(Checker.HoldViolations)
+
+    if gui:
+        target_flow = Flow.factory.get("OpenInOpenROAD")
+
+    # Run the flow
+    config_path = os.path.join(__dir__, "config.yaml")
+    config = yaml.safe_load(open(config_path))
+
+    flow = target_flow(
+        config,
+        design_dir=__dir__,
+        pdk_root=pdk_root,
+        pdk=pdk,
+    )
+    state_out = flow.start(tag=run_tag)
+
+    # Check for hold violations
+    step = Checker.HoldViolations(config=flow.config, state_in=state_out)
+    got_hold_violations = False
+    try:
+        current_state = step.start(
+            step_dir=os.path.join(__dir__, "runs", run_tag, "xx-checker-holdviolations"),
+        )
+    except DeferredStepError as e:
+        print(e)
+        got_hold_violations = True
+
+    if not got_hold_violations:
+        # Don't expect hold violations for gf180mcu
+        if not "gf180mcu" in pdk:
+            raise FlowError("Expected hold violations, got none!") from None
+
+    print("Got hold violations, as expected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hold_violations_1/src/hold_violations_1.sv
+++ b/hold_violations_1/src/hold_violations_1.sv
@@ -1,0 +1,19 @@
+module hold_violations_1 (
+    input  clk_i,
+    input  rst_ni,
+
+    input  shift_i,
+    output shift_o
+);
+
+    localparam BITS = 32;
+    logic [BITS-1:0] register;
+    
+    always_ff @(posedge clk_i) begin
+        register[0] <= shift_i;
+        register[BITS-1:1] <= register[BITS-2:0];
+    end
+    
+    assign shift_o = register[BITS-1];
+
+endmodule

--- a/hold_violations_2/base.sdc
+++ b/hold_violations_2/base.sdc
@@ -1,0 +1,84 @@
+set clock_port __VIRTUAL_CLK__
+if { [info exists ::env(CLOCK_PORT)] } {
+    set port_count [llength $::env(CLOCK_PORT)]
+
+    if { $port_count == "0" } {
+        puts "\[WARNING] No CLOCK_PORT found. A dummy clock will be used."
+    } elseif { $port_count != "1" } {
+        puts "\[WARNING] Multi-clock files are not currently supported by the base SDC file. Only the first clock will be constrained."
+    }
+
+    if { $port_count > "0" } {
+        set ::clock_port [lindex $::env(CLOCK_PORT) 0]
+    }
+}
+set port_args [get_ports $clock_port]
+puts "\[INFO] Using clock $clock_port…"
+create_clock {*}$port_args -name $clock_port -period $::env(CLOCK_PERIOD)
+
+set input_delay_value [expr $::env(CLOCK_PERIOD) * $::env(IO_DELAY_CONSTRAINT) / 100]
+set output_delay_value [expr $::env(CLOCK_PERIOD) * $::env(IO_DELAY_CONSTRAINT) / 100]
+puts "\[INFO] Setting output delay to: $output_delay_value"
+puts "\[INFO] Setting input delay to: $input_delay_value"
+
+set_max_fanout $::env(MAX_FANOUT_CONSTRAINT) [current_design]
+if { [info exists ::env(MAX_TRANSITION_CONSTRAINT)] } {
+    set_max_transition $::env(MAX_TRANSITION_CONSTRAINT) [current_design]
+}
+if { [info exists ::env(MAX_CAPACITANCE_CONSTRAINT)] } {
+    set_max_capacitance $::env(MAX_CAPACITANCE_CONSTRAINT) [current_design]
+} 
+
+set clk_input [get_port $clock_port]
+set clk_indx [lsearch [all_inputs] $clk_input]
+set all_inputs_wo_clk [lreplace [all_inputs] $clk_indx $clk_indx ""]
+
+#set rst_input [get_port resetn]
+#set rst_indx [lsearch [all_inputs] $rst_input]
+#set all_inputs_wo_clk_rst [lreplace $all_inputs_wo_clk $rst_indx $rst_indx ""]
+set all_inputs_wo_clk_rst $all_inputs_wo_clk
+
+# correct resetn
+set clocks [get_clocks $clock_port]
+
+# TODO
+set_input_delay -min 0 -clock $clocks $all_inputs_wo_clk_rst
+set_input_delay -max 8 -clock $clocks $all_inputs_wo_clk_rst
+
+#set_input_delay $input_delay_value -clock $clocks $all_inputs_wo_clk_rst
+set_output_delay $output_delay_value -clock $clocks [all_outputs]
+
+if { ![info exists ::env(SYNTH_CLK_DRIVING_CELL)] } {
+    set ::env(SYNTH_CLK_DRIVING_CELL) $::env(SYNTH_DRIVING_CELL)
+}
+
+set_driving_cell \
+    -lib_cell [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 0] \
+    -pin [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 1] \
+    $all_inputs_wo_clk_rst
+
+set_driving_cell \
+    -lib_cell [lindex [split $::env(SYNTH_CLK_DRIVING_CELL) "/"] 0] \
+    -pin [lindex [split $::env(SYNTH_CLK_DRIVING_CELL) "/"] 1] \
+    $clk_input
+
+set cap_load [expr $::env(OUTPUT_CAP_LOAD) / 1000.0]
+puts "\[INFO] Setting load to: $cap_load"
+set_load $cap_load [all_outputs]
+
+puts "\[INFO] Setting clock uncertainty to: $::env(CLOCK_UNCERTAINTY_CONSTRAINT)"
+set_clock_uncertainty $::env(CLOCK_UNCERTAINTY_CONSTRAINT) $clocks
+
+puts "\[INFO] Setting clock transition to: $::env(CLOCK_TRANSITION_CONSTRAINT)"
+set_clock_transition $::env(CLOCK_TRANSITION_CONSTRAINT) $clocks
+
+puts "\[INFO] Setting timing derate to: $::env(TIME_DERATING_CONSTRAINT)%"
+set_timing_derate -early [expr 1-[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
+set_timing_derate -late [expr 1+[expr $::env(TIME_DERATING_CONSTRAINT) / 100]]
+
+if { [info exists ::env(OPENLANE_SDC_IDEAL_CLOCKS)] && $::env(OPENLANE_SDC_IDEAL_CLOCKS) } {
+    unset_propagated_clock [all_clocks]
+} else {
+    set_propagated_clock [all_clocks]
+}
+

--- a/hold_violations_2/config.yaml
+++ b/hold_violations_2/config.yaml
@@ -1,0 +1,20 @@
+meta:
+  version: 3
+  flow: Classic
+  substituting_steps:
+    # Needed because of https://github.com/The-OpenROAD-Project/OpenROAD/issues/8642
+    OpenROAD.Resizer* : null
+
+DESIGN_NAME: hold_violations_2
+VERILOG_FILES: dir::src/*.sv
+CLOCK_PORT: clk_i
+CLOCK_PERIOD: 10 # 10ns = 100MHz
+
+FP_CORE_UTIL: 30
+
+RSZ_DONT_TOUCH_RX: shift_i
+
+# SDC files
+PNR_SDC_FILE: dir::base.sdc
+SIGNOFF_SDC_FILE: dir::base.sdc
+FALLBACK_SDC: dir::base.sdc

--- a/hold_violations_2/harden.py
+++ b/hold_violations_2/harden.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright 2025 LibreLane Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import yaml
+import click
+
+from librelane.flows import Flow, FlowError
+from librelane.config import Macro
+from librelane.steps import Checker, OpenROAD, DeferredStepError
+
+__dir__ = os.path.dirname(os.path.realpath(__file__))
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option("--pdk-root", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--pdk", type=str)
+@click.option("--run-tag", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--gui", is_flag=True)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def main(
+    pdk_root,
+    pdk,
+    run_tag,
+    gui,
+    args,
+):
+    target_flow = Flow.factory.get("Classic")
+
+    # Don't throw exception on hold violations
+    target_flow.Steps.remove(Checker.HoldViolations)
+
+    # Needed because of https://github.com/The-OpenROAD-Project/OpenROAD/issues/8642
+    target_flow.Steps.remove(OpenROAD.ResizerTimingPostCTS)
+    target_flow.Steps.remove(OpenROAD.ResizerTimingPostGRT)
+
+    if gui:
+        target_flow = Flow.factory.get("OpenInOpenROAD")
+
+    # Run the flow
+    config_path = os.path.join(__dir__, "config.yaml")
+    config = yaml.safe_load(open(config_path))
+
+    flow = target_flow(
+        config,
+        design_dir=__dir__,
+        pdk_root=pdk_root,
+        pdk=pdk,
+    )
+    state_out = flow.start(tag=run_tag)
+
+    # Check for hold violations
+    step = Checker.HoldViolations(config=flow.config, state_in=state_out)
+    got_hold_violations = False
+    try:
+        current_state = step.start(
+            step_dir=os.path.join(__dir__, "runs", run_tag, "xx-checker-holdviolations"),
+        )
+    except DeferredStepError as e:
+        print(e)
+        got_hold_violations = True
+
+    if not got_hold_violations:
+        raise FlowError("Expected hold violations, got none!") from None
+
+    print("Got hold violations, as expected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hold_violations_2/src/hold_violations_2.sv
+++ b/hold_violations_2/src/hold_violations_2.sv
@@ -1,0 +1,19 @@
+module hold_violations_2 (
+    input  clk_i,
+    input  rst_ni,
+
+    input  shift_i,
+    output shift_o
+);
+
+    localparam BITS = 32;
+    logic [BITS-1:0] register;
+    
+    always_ff @(posedge clk_i) begin
+        register[0] <= shift_i;
+        register[BITS-1:1] <= register[BITS-2:0];
+    end
+    
+    assign shift_o = register[BITS-1];
+
+endmodule

--- a/hold_violations_3/harden.py
+++ b/hold_violations_3/harden.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright 2025 LibreLane Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import yaml
+import click
+
+from librelane.flows import Flow, FlowError
+from librelane.config import Macro
+from librelane.steps import Checker, DeferredStepError
+
+__dir__ = os.path.dirname(os.path.realpath(__file__))
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option("--pdk-root", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--pdk", type=str)
+@click.option("--run-tag", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--gui", is_flag=True)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def main(
+    pdk_root,
+    pdk,
+    run_tag,
+    gui,
+    args,
+):
+    target_flow = Flow.factory.get("Classic")
+
+    # Don't throw exception on hold violations
+    target_flow.Steps.remove(Checker.HoldViolations)
+
+    if gui:
+        target_flow = Flow.factory.get("OpenInOpenROAD")
+
+    # Build the flipflop macro
+    ff_dir = os.path.join(__dir__, "src", "flipflop")
+    ff_config_path = os.path.join(ff_dir, "config.yaml")
+    ff_config = yaml.safe_load(open(ff_config_path))
+    design_dir = os.path.join(__dir__, "src", "flipflop")
+
+    flow = target_flow(
+        ff_config,
+        design_dir=design_dir,
+        pdk_root=pdk_root,
+        pdk=pdk,
+    )
+    ff_state_out = flow.start(tag=run_tag)
+
+    ff_macro = Macro.from_state(ff_state_out)
+    ff_macro.instantiate("my_ff_1", (35, 35))
+    ff_macro.instantiate("my_ff_2", (35, 75))
+    ff_macro.instantiate("my_ff_3", (70, 35))
+    ff_macro.instantiate("my_ff_4", (70, 75))
+
+    # Build the top level
+    flow_cfg = {
+        # Design
+        "DESIGN_NAME": "hold_violations_3",
+        # Sources
+        "VERILOG_FILES": [os.path.join(__dir__, "src", "hold_violations_3.sv")],
+        # Clock
+        "CLOCK_PORT": "clk_i",
+        "CLOCK_PERIOD": 10,  # 10ns = 100MHz
+        # Die area
+        "FP_SIZING": "absolute",
+        "DIE_AREA": [0, 0, 135, 135],
+        "PL_TARGET_DENSITY_PCT": 60,
+        # Macros
+        "MACROS": {"flipflop": ff_macro},
+        # PDN
+        "PDN_HOFFSET": 5,
+        "PDN_HPITCH": 12.4,
+        "PDN_VOFFSET": 5,
+        "PDN_VPITCH": 15,
+        "FP_MACRO_HORIZONTAL_HALO": 3.5,
+        "FP_MACRO_VERTICAL_HALO": 3.5,
+        "VDD_PIN": "VPWR",
+        "GND_PIN": "VGND",
+        # Save area
+        "BOTTOM_MARGIN_MULT": 2,
+        "TOP_MARGIN_MULT": 2,
+        "LEFT_MARGIN_MULT": 4,
+        "RIGHT_MARGIN_MULT": 4,
+        # Don't touch
+        "RSZ_DONT_TOUCH_RX": "data_o.*",
+    }
+
+    flow = target_flow(
+        flow_cfg,
+        design_dir=__dir__,
+        pdk_root=pdk_root,
+        pdk=pdk,
+    )
+    top_state_out = flow.start(tag=run_tag)
+
+    # Check for hold violations
+    step = Checker.HoldViolations(config=flow.config, state_in=top_state_out)
+    got_hold_violations = False
+    try:
+        current_state = step.start(
+            step_dir=os.path.join(__dir__, "runs", run_tag, "xx-checker-holdviolations"),
+        )
+    except DeferredStepError as e:
+        print(e)
+        got_hold_violations = True
+
+    if not got_hold_violations:
+        # Don't expect hold violations for gf180mcu
+        if not "gf180mcu" in pdk:
+            raise FlowError("Expected hold violations, got none!") from None
+
+    print("Got hold violations, as expected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hold_violations_3/src/flipflop/config.yaml
+++ b/hold_violations_3/src/flipflop/config.yaml
@@ -1,0 +1,32 @@
+# Design
+DESIGN_NAME           : "flipflop"
+
+# Sources
+VERILOG_FILES         : dir::flipflop.sv
+
+# Clock
+CLOCK_PORT            : "clk_i"
+CLOCK_PERIOD          : 10 # 10ns = 100MHz
+
+# Die area
+FP_SIZING             : "absolute"
+DIE_AREA              : [0, 0, 28, 20]
+PL_TARGET_DENSITY_PCT : 60
+
+# PDN
+PDN_MULTILAYER        : False
+PDN_VOFFSET           : 5
+PDN_VPITCH            : 12.4
+PDN_EXTEND_TO         : boundary
+VDD_PIN               : "VPWR"
+GND_PIN               : "VGND"
+
+# Save area
+BOTTOM_MARGIN_MULT    : 1
+TOP_MARGIN_MULT       : 1
+LEFT_MARGIN_MULT      : 4
+RIGHT_MARGIN_MULT     : 4
+
+# No input/output buffers
+DESIGN_REPAIR_BUFFER_INPUT_PORTS: false
+DESIGN_REPAIR_BUFFER_OUTPUT_PORTS: false

--- a/hold_violations_3/src/flipflop/flipflop.sv
+++ b/hold_violations_3/src/flipflop/flipflop.sv
@@ -1,0 +1,12 @@
+module flipflop (
+    input  logic clk_i,
+
+    input  logic data_i,
+    output logic data_o
+);
+
+    always_ff @(posedge clk_i) begin
+        data_o <= data_i;
+    end
+
+endmodule

--- a/hold_violations_3/src/hold_violations_3.sv
+++ b/hold_violations_3/src/hold_violations_3.sv
@@ -1,0 +1,54 @@
+module hold_violations_3 (
+    `ifdef USE_POWER_PINS
+    inout VPWR,
+    inout VGND,
+    `endif
+
+    input  clk_i,
+    input  shift_i,
+    output shift_o
+);
+
+    logic [2:0] data_o;
+
+    flipflop my_ff_1 (
+        `ifdef USE_POWER_PINS
+        .VPWR (VPWR),
+        .VGND (VGND),
+        `endif
+        .clk_i  (clk_i),
+        .data_i (shift_i),
+        .data_o (data_o[0])
+    );
+
+    flipflop my_ff_2 (
+        `ifdef USE_POWER_PINS
+        .VPWR (VPWR),
+        .VGND (VGND),
+        `endif
+        .clk_i  (clk_i),
+        .data_i (data_o[0]),
+        .data_o (data_o[1])
+    );
+
+    flipflop my_ff_3 (
+        `ifdef USE_POWER_PINS
+        .VPWR (VPWR),
+        .VGND (VGND),
+        `endif
+        .clk_i  (clk_i),
+        .data_i (data_o[1]),
+        .data_o (data_o[2])
+    );
+
+    flipflop my_ff_4 (
+        `ifdef USE_POWER_PINS
+        .VPWR (VPWR),
+        .VGND (VGND),
+        `endif
+        .clk_i  (clk_i),
+        .data_i (data_o[2]),
+        .data_o (shift_o)
+    );
+
+endmodule


### PR DESCRIPTION
This PR adds three new testcases to ensure hold violations are occurring.
The testcases are implemented without the use of specific standard cells, which makes them easier to port to other PDKs.

- hold_violations_1: Implements a shift register and sets the wires in between as don't touch. On sky130 and ihp-sg13g2 this leads to hold violations, it seems on gf180mcu the clock-to-Q delay is larger than the hold time.
- hold_violations_2: Using a custom SDC, the set_input_delay is set to min 0. This leads to hold violations for all current PDKs.
- hold_violations_3: First, implements a simple macro with a single flip flop without any buffers. This macro is then instantiated four times in a top-level design to implement a shift register. Again, this leads to hold violations in sky130 and ihp-sg13g2.