### PR TITLE
fix: correct bondpad name

### DIFF
--- a/full_chip/config.yaml
+++ b/full_chip/config.yaml
@@ -138,7 +138,7 @@ EXTRA_LEFS:
 - dir::ip/bondpad_70x70_novias/lef/bondpad_70x70_novias.lef
 
 IGNORE_DISCONNECTED_MODULES:
-- bondpad_70x70
+- bondpad_70x70_novias
 
 # Maximum metal width without slotting: 30um
 PDN_CORE_RING_VWIDTH: 15


### PR DESCRIPTION
Prevents the "has no power pins" warnings.