### PR TITLE
fix: increase clock period slightly for two designs, extract unique for full_chip_sky130

### DIFF
--- a/EF_TCC32/config.json
+++ b/EF_TCC32/config.json
@@ -2,7 +2,7 @@
     "DESIGN_NAME": "EF_TCC32",
     "VERILOG_FILES": ["dir::./src/hdl/rtl/EF_TCC32.v"],
     "CLOCK_PORT": "clk",
-    "CLOCK_PERIOD": 14,
+    "CLOCK_PERIOD": 16,
     "FP_IO_MODE": "annealing",
     "SYNTH_EXCLUSION_CELL_LIST": "dir::./no_synth.cells",
     "PNR_EXCLUSION_CELL_LIST": "dir::./drc_exclude.cells",

--- a/MS_CLK_RST/signoff.sdc
+++ b/MS_CLK_RST/signoff.sdc
@@ -13,7 +13,7 @@ set_output_delay 0.0000 -clock [get_clocks {__VIRTUAL_CLK__}] -add_delay [get_po
 set_false_path -from [get_ports {one}]
 set_false_path -from [get_ports {zero}]
 
-create_clock -name CLK -period 5 [get_pins PoR.ROSC_CLKBUF_1/X]
+create_clock -name CLK -period 6 [get_pins PoR.ROSC_CLKBUF_1/X]
 set CLK_500kHz_pin [get_pins -of_objects {PoR.clk_div[8]} -filter lib_pin_name==Q]
 create_clock -name CLK_500kHz -period 200 $CLK_500kHz_pin
 

--- a/full_chip_sky130/config.yaml
+++ b/full_chip_sky130/config.yaml
@@ -154,8 +154,5 @@ PDN_CORE_RING_CONNECT_TO_PAD_LAYERS: [met3]
 PDN_ENABLE_PINS: False # xxx does not contain any terminals
 ERROR_ON_PDN_VIOLATIONS: False # to prevent false positive error
 
-# Because we have multiple power pads for one power domain
-MAGIC_EXT_UNIQUE: notopports
-
 # Due to https://github.com/The-OpenROAD-Project/OpenROAD/issues/10256
 ERROR_ON_KLAYOUT_DRC: False


### PR DESCRIPTION
Required for https://github.com/librelane/librelane/pull/916

We now support power/ground busses.